### PR TITLE
update duplicated classes

### DIFF
--- a/src/classes.txt
+++ b/src/classes.txt
@@ -1471,7 +1471,7 @@
 .right-72                      
 .right-80                      
 .right-96                      
-.bottom-0                      .sm:right-0                       .md:right-0                       .lg:right-0                       .xl:right-0                       .2xl:right-0
+.bottom-0                      .sm:bottom-0                       .md:bottom-0                       .lg:bottom-0                       .xl:bottom-0                       .2xl:bottom-0
 .bottom-0.5                    
 .bottom-1                      
 .bottom-1.5                    


### PR DESCRIPTION
this commit fixes the missing classes for `bottom-0`

I wrote a script to check whether all classes I've used are included when I realized that `bottom-0` didn't have a corresponding `.sm:bottom-0` on line 1474. `.right-0` classes are included on line 1440